### PR TITLE
navigator_graph_url() added

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,6 +78,10 @@ explain.compute_explanation_dag()  # it can also be omitted
 print(explain.explanation_dag())
 ```
 
+Methods `Explain.navigator_graph_url()` and `Explain.show_navigator_graph()` can be used, respectively,
+to obtain the url of a web-based UI for navigating the dag, and to open the default browser
+at that url.
+
 All the above commands and queries can be combined.
 Actually, required steps are performed automatically when required.
-Finally, it is possible to ask for more minimal assumption sets, explanation sequences and DAGs either by using the keyword `repeat=<int>` in the `compute_*` commands, or the keyword `index=<int>` in the queries (`minimal_assumption_set()`, `explanation_sequence()`, `explanation_dag`, `show_navigator_graph()`).
+Finally, it is possible to ask for more minimal assumption sets, explanation sequences and DAGs either by using the keyword `repeat=<int>` in the `compute_*` commands, or the keyword `index=<int>` in the queries (`minimal_assumption_set()`, `explanation_sequence()`, `explanation_dag`, `navigator_graph_url()`, `show_navigator_graph()`).

--- a/xasp/entities.py
+++ b/xasp/entities.py
@@ -192,12 +192,16 @@ class Explain:
             **kwargs,
         )
 
-    def show_navigator_graph(self, index: int = -1) -> None:
+    def navigator_graph_url(self, index: int = -1) -> str:
         self.compute_igraph(index)
         url = "https://xasp-navigator.netlify.app/#"
         # url = "http://localhost:5173/#"
         json_dump = json.dumps(self.navigator_graph(index), separators=(',', ':')).encode()
         url += base64.b64encode(zlib.compress(json_dump)).decode() + '%21'
+        return url
+
+    def show_navigator_graph(self, index: int = -1) -> None:
+        url = self.navigator_graph_url(index)
         webbrowser.open(url, new=0, autoraise=True)
 
     @property


### PR DESCRIPTION
Added `navigator_graph_url()` to display the URL of the web-based UI instead of opening the browser.
I also expanded the readme with a short description of `navigator_graph_url()` and `show_navigator_graph()`.